### PR TITLE
Provide an option to use the path as a package name

### DIFF
--- a/src/main/java/hudson/plugins/checkstyle/CheckStylePublisher.java
+++ b/src/main/java/hudson/plugins/checkstyle/CheckStylePublisher.java
@@ -15,6 +15,7 @@ import hudson.plugins.analysis.util.PluginLogger;
 import hudson.plugins.analysis.util.StringPluginLogger;
 import hudson.plugins.checkstyle.parser.CheckStyleParser;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
@@ -35,6 +36,8 @@ public class CheckStylePublisher extends HealthAwarePublisher {
     private static final String DEFAULT_PATTERN = "**/checkstyle-result.xml";
     /** Ant file-set pattern of files to work with. */
     private final String pattern;
+    /** Determine whether path have to be displayed in the GUI. */ 
+    private final boolean shouldShowPath;
 
     /**
      * Creates a new instance of <code>CheckstylePublisher</code>.
@@ -92,6 +95,8 @@ public class CheckStylePublisher extends HealthAwarePublisher {
      *            determines whether module names should be derived from Maven POM or Ant build files
      * @param pattern
      *            Ant file-set pattern to scan for Checkstyle files
+     * @param shouldShowPath
+     *            determines whether path have to be displayed in the GUI
      */
     // CHECKSTYLE:OFF
     @SuppressWarnings("PMD.ExcessiveParameterList")
@@ -103,7 +108,7 @@ public class CheckStylePublisher extends HealthAwarePublisher {
             final String failedTotalAll, final String failedTotalHigh, final String failedTotalNormal, final String failedTotalLow,
             final String failedNewAll, final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
             final boolean canRunOnFailed, final boolean shouldDetectModules,
-            final String pattern) {
+            final String pattern, final boolean shouldShowPath) {
         super(healthy, unHealthy, thresholdLimit, defaultEncoding, useDeltaValues,
                 unstableTotalAll, unstableTotalHigh, unstableTotalNormal, unstableTotalLow,
                 unstableNewAll, unstableNewHigh, unstableNewNormal, unstableNewLow,
@@ -111,6 +116,7 @@ public class CheckStylePublisher extends HealthAwarePublisher {
                 failedNewAll, failedNewHigh, failedNewNormal, failedNewLow,
                 canRunOnFailed, shouldDetectModules, PLUGIN_NAME);
         this.pattern = pattern;
+        this.shouldShowPath = shouldShowPath;
     }
     // CHECKSTYLE:ON
 
@@ -121,6 +127,24 @@ public class CheckStylePublisher extends HealthAwarePublisher {
      */
     public String getPattern() {
         return pattern;
+    }
+
+    /**
+     * Returns whether path have to be displayed in the GUI.
+     *
+     * @return whether path have to be displayed in the GUI
+     */
+    public boolean getShouldShowPath() {
+        return shouldShowPath;
+    }
+    
+    /**
+     * Returns whether path have to be displayed in the GUI.
+     *
+     * @return whether path have to be displayed in the GUI
+     */
+    public boolean shouldShowPath() {
+        return shouldShowPath;
     }
 
     /** {@inheritDoc} */
@@ -136,7 +160,7 @@ public class CheckStylePublisher extends HealthAwarePublisher {
 
         FilesParser parser = new FilesParser(new StringPluginLogger(PLUGIN_NAME),
                 StringUtils.defaultIfEmpty(getPattern(), DEFAULT_PATTERN),
-                new CheckStyleParser(getDefaultEncoding()),
+                new CheckStyleParser(getDefaultEncoding(), shouldShowPath(), build.getProject().getRootDir().getPath() + File.separator + build.getWorkspace().getName()),
                 shouldDetectModules(), isMavenBuild(build));
         ParserResult project = build.getWorkspace().act(parser);
         logger.logLines(project.getLogMessages());

--- a/src/main/java/hudson/plugins/checkstyle/CheckStyleReporter.java
+++ b/src/main/java/hudson/plugins/checkstyle/CheckStyleReporter.java
@@ -32,6 +32,9 @@ public class CheckStyleReporter extends HealthAwareReporter<CheckStyleResult> {
 
     /** Default Checkstyle pattern. */
     private static final String CHECKSTYLE_XML_FILE = "checkstyle-result.xml";
+    
+    /** Do we extract the path if the package cannot be found. */
+    private boolean shouldShowPath;
 
     /**
      * Creates a new instance of <code>CheckStyleReporter</code>.
@@ -83,6 +86,8 @@ public class CheckStyleReporter extends HealthAwareReporter<CheckStyleResult> {
      *            annotation threshold
      * @param canRunOnFailed
      *            determines whether the plug-in can run for failed builds, too
+     * @param shouldShowPath
+     *            determines whether path have to be displayed in the GUI
      */
     // CHECKSTYLE:OFF
     @SuppressWarnings("PMD.ExcessiveParameterList")
@@ -92,13 +97,14 @@ public class CheckStyleReporter extends HealthAwareReporter<CheckStyleResult> {
             final String unstableNewAll, final String unstableNewHigh, final String unstableNewNormal, final String unstableNewLow,
             final String failedTotalAll, final String failedTotalHigh, final String failedTotalNormal, final String failedTotalLow,
             final String failedNewAll, final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
-            final boolean canRunOnFailed) {
+            final boolean canRunOnFailed, final boolean shouldShowPath) {
         super(healthy, unHealthy, thresholdLimit, useDeltaValues,
                 unstableTotalAll, unstableTotalHigh, unstableTotalNormal, unstableTotalLow,
                 unstableNewAll, unstableNewHigh, unstableNewNormal, unstableNewLow,
                 failedTotalAll, failedTotalHigh, failedTotalNormal, failedTotalLow,
                 failedNewAll, failedNewHigh, failedNewNormal, failedNewLow,
                 canRunOnFailed, PLUGIN_NAME);
+        this.shouldShowPath = shouldShowPath;
     }
     // CHECKSTYLE:ON
 
@@ -111,10 +117,30 @@ public class CheckStyleReporter extends HealthAwareReporter<CheckStyleResult> {
     public ParserResult perform(final MavenBuildProxy build, final MavenProject pom,
             final MojoInfo mojo, final PluginLogger logger) throws InterruptedException, IOException {
         FilesParser checkstyleCollector = new FilesParser(new StringPluginLogger(PLUGIN_NAME),
-                CHECKSTYLE_XML_FILE, new CheckStyleParser(getDefaultEncoding()), getModuleName(pom));
+                CHECKSTYLE_XML_FILE, new CheckStyleParser(getDefaultEncoding(), shouldShowPath(), build.getProjectRootDir().getName())
+                , getModuleName(pom));
 
         return getTargetPath(pom).act(checkstyleCollector);
     }
+    
+    /**
+     * Returns whether path have to be displayed in the GUI.
+     *
+     * @return whether path have to be displayed in the GUI
+     */
+    public boolean getShouldShowPath() {
+        return shouldShowPath;
+    }
+    
+    /**
+     * Returns whether path have to be displayed in the GUI.
+     *
+     * @return whether path have to be displayed in the GUI
+     */
+    public boolean shouldShowPath() {
+        return shouldShowPath;
+    }
+
 
     @Override
     protected CheckStyleResult createResult(final MavenBuild build, final ParserResult project) {

--- a/src/main/resources/hudson/plugins/checkstyle/CheckStylePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/checkstyle/CheckStylePublisher/config.jelly
@@ -6,5 +6,9 @@
   </f:entry>
   <f:advanced>
     <u:advanced id="checkstyle"/>
+    <f:entry title="${%Show file path}" field="shouldShowPath"
+           description="${%description.shouldShowPath}">
+        <f:checkbox/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/checkstyle/CheckStylePublisher/config.properties
+++ b/src/main/resources/hudson/plugins/checkstyle/CheckStylePublisher/config.properties
@@ -3,3 +3,4 @@ description.pattern=<a href="{0}">Fileset 'includes'</a> \
                  Basedir of the fileset is <a href="ws/">the workspace root</a>. \
                  If no value is set, then the default '**/checkstyle-result.xml' is used. Be sure not to include any \
              non-report files into this pattern.
+description.shouldShowPath=Display the relative path of each file on the result page.

--- a/src/main/resources/hudson/plugins/checkstyle/CheckStyleReporter/config.jelly
+++ b/src/main/resources/hudson/plugins/checkstyle/CheckStyleReporter/config.jelly
@@ -2,5 +2,9 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:u="/util">
   <f:advanced>
     <u:advancedMaven id="checkstyle"/>
+    <f:entry title="${%Show file path}" field="shouldShowPath"
+           description="${%description.shouldShowPathh}">
+        <f:checkbox/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/checkstyle/CheckStyleReporter/config.properties
+++ b/src/main/resources/hudson/plugins/checkstyle/CheckStyleReporter/config.properties
@@ -1,0 +1,1 @@
+description.shouldShowPath=Display the relative path of each file on the result page.

--- a/src/test/java/hudson/plugins/checkstyle/parser/CheckStyleParserTest.java
+++ b/src/test/java/hudson/plugins/checkstyle/parser/CheckStyleParserTest.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 
 /**
@@ -33,7 +34,8 @@ public class CheckStyleParserTest {
         try {
             inputStream = CheckStyleParserTest.class.getResourceAsStream("checkstyle.xml");
 
-            annotations = new CheckStyleParser().parse(inputStream, "empty");
+            annotations = new CheckStyleParser(StringUtils.EMPTY, true, "X:\\Build\\Results\\jobs\\Maven\\workspace")
+                    .parse(inputStream, "empty");
         }
         finally {
             IOUtils.closeQuietly(inputStream);


### PR DESCRIPTION
Here is a patch I made to allow users of Checkstyle who treat non-java files to use the path as a package name.

In this way, the warnings can be filtered in a logical sense.

Hoping you will like it,
Regars
