### PR TITLE
[JENKINS-29648] Make Checkstyle Plugin compatible with Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea/
+work/

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>1.59</version>
-    <relativePath>../analysis-pom/pom.xml</relativePath>
+    <version>1.63</version>
   </parent>
 
   <artifactId>checkstyle</artifactId>
@@ -16,6 +15,10 @@
   <description>This plug-in generates the trend report for
     Checkstyle, an open source static code analysis program.
   </description>
+
+  <properties>
+    <workflow-jenkins-plugin.version>1.4</workflow-jenkins-plugin.version>
+  </properties>
 
   <licenses>
     <license>
@@ -34,7 +37,7 @@
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>analysis-core</artifactId>
-      <version>1.73-SNAPSHOT</version>
+      <version>1.73-beta-SNAPSHOT</version><!-- TODO: change to 1.73 before release -->
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -47,9 +50,32 @@
       <version>2.11.0</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>analysis-test</artifactId>
       <version>1.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>${workflow-jenkins-plugin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>${workflow-jenkins-plugin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>${workflow-jenkins-plugin.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/checkstyle/CheckStyleReporterResult.java
+++ b/src/main/java/hudson/plugins/checkstyle/CheckStyleReporterResult.java
@@ -1,6 +1,7 @@
 package hudson.plugins.checkstyle;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.ParserResult;
 import hudson.plugins.analysis.core.ResultAction;
 import hudson.plugins.analysis.core.BuildResult;
@@ -28,8 +29,33 @@ public class CheckStyleReporterResult extends CheckStyleResult {
      * @param useStableBuildAsReference
      *            determines whether only stable builds should be used as
      *            reference builds or not
+     *
+     * @deprecated see {@link #CheckStyleReporterResult(Run, String, ParserResult, boolean, boolean)}
      */
-    public CheckStyleReporterResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final ParserResult result,
+    @Deprecated
+    public CheckStyleReporterResult(final AbstractBuild<?, ?> build, final String defaultEncoding,
+            final ParserResult result, final boolean usePreviousBuildAsReference,
+            final boolean useStableBuildAsReference) {
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference);
+    }
+
+    /**
+     * Creates a new instance of {@link CheckStyleReporterResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param result
+     *            the parsed result with all annotations
+     * @param usePreviousBuildAsReference
+     *            determines whether to use the previous build as the reference
+     *            build
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     */
+    public CheckStyleReporterResult(final Run<?, ?> build, final String defaultEncoding, final ParserResult result,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
         super(build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
                 CheckStyleMavenResultAction.class);

--- a/src/main/java/hudson/plugins/checkstyle/CheckStyleResult.java
+++ b/src/main/java/hudson/plugins/checkstyle/CheckStyleResult.java
@@ -3,6 +3,7 @@ package hudson.plugins.checkstyle;
 import com.thoughtworks.xstream.XStream;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.BuildHistory;
 import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.analysis.core.ParserResult;
@@ -33,8 +34,33 @@ public class CheckStyleResult extends BuildResult {
      * @param useStableBuildAsReference
      *            determines whether only stable builds should be used as
      *            reference builds or not
+     *
+     * @deprecated use {@link #CheckStyleResult(Run, String, ParserResult, boolean, boolean, Class)}
      */
+    @Deprecated
     public CheckStyleResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final ParserResult result,
+            final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference);
+    }
+
+
+    /**
+     * Creates a new instance of {@link CheckStyleResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param result
+     *            the parsed result with all annotations
+     * @param usePreviousBuildAsReference
+     *            determines whether to use the previous build as the reference
+     *            build
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     */
+    public CheckStyleResult(final Run<?, ?> build, final String defaultEncoding, final ParserResult result,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
         this(build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
                 CheckStyleResultAction.class);
@@ -54,16 +80,51 @@ public class CheckStyleResult extends BuildResult {
      *            reference builds or not
      * @param actionType
      *            the type of the result action
+     *
+     * @deprecated use {@link #CheckStyleResult(Run, String, ParserResult, boolean, boolean, Class)}
      */
+    @Deprecated
     protected CheckStyleResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final ParserResult result,
+            final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
+            final Class<? extends ResultAction<CheckStyleResult>> actionType) {
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
+                actionType);
+
+    }
+
+    /**
+     * Creates a new instance of {@link CheckStyleResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param result
+     *            the parsed result with all annotations
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     * @param actionType
+     *            the type of the result action
+     */
+    protected CheckStyleResult(final Run<?, ?> build, final String defaultEncoding, final ParserResult result,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
             final Class<? extends ResultAction<CheckStyleResult>> actionType) {
         this(build, new BuildHistory(build, actionType, usePreviousBuildAsReference, useStableBuildAsReference),
                 result, defaultEncoding, true);
     }
 
-    CheckStyleResult(final AbstractBuild<?, ?> build, final BuildHistory history,
-            final ParserResult result, final String defaultEncoding, final boolean canSerialize) {
+    /**
+     * @deprecated use {@link #CheckStyleResult(Run, BuildHistory, ParserResult, String, boolean)}
+     */
+    @Deprecated
+    CheckStyleResult(final AbstractBuild<?, ?> build, final BuildHistory history, final ParserResult result,
+            final String defaultEncoding, final boolean canSerialize) {
+        this((Run<?, ?>) build, history, result, defaultEncoding, canSerialize);
+    }
+
+    CheckStyleResult(final Run<?, ?> build, final BuildHistory history,
+                     final ParserResult result, final String defaultEncoding, final boolean canSerialize) {
         super(build, history, result, defaultEncoding);
 
         if (canSerialize) {

--- a/src/main/java/hudson/plugins/checkstyle/CheckStyleResultAction.java
+++ b/src/main/java/hudson/plugins/checkstyle/CheckStyleResultAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.checkstyle;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.AbstractResultAction;
 import hudson.plugins.analysis.core.HealthDescriptor;
 import hudson.plugins.analysis.core.PluginDescriptor;
@@ -26,8 +27,27 @@ public class CheckStyleResultAction extends AbstractResultAction<CheckStyleResul
      *            health descriptor
      * @param result
      *            the result in this build
+     *
+     * @deprecated see use {@link #CheckStyleResultAction(Run, HealthDescriptor, CheckStyleResult)}
      */
-    public CheckStyleResultAction(final AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor, final CheckStyleResult result) {
+    @Deprecated
+    public CheckStyleResultAction(final AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor,
+            final CheckStyleResult result) {
+        this((Run<?, ?>) owner, new CheckStyleHealthDescriptor(healthDescriptor), result);
+    }
+
+    /**
+     * Creates a new instance of <code>CheckStyleResultAction</code>.
+     *
+     * @param owner
+     *            the associated build of this action
+     * @param healthDescriptor
+     *            health descriptor
+     * @param result
+     *            the result in this build
+     */
+    public CheckStyleResultAction(final Run<?, ?> owner, final HealthDescriptor healthDescriptor,
+            final CheckStyleResult result) {
         super(owner, new CheckStyleHealthDescriptor(healthDescriptor), result);
     }
 

--- a/src/test/java/hudson/plugins/checkstyle/CheckstyleWorkflowTest.java
+++ b/src/test/java/hudson/plugins/checkstyle/CheckstyleWorkflowTest.java
@@ -1,0 +1,77 @@
+package hudson.plugins.checkstyle;
+
+import hudson.FilePath;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+
+public class CheckstyleWorkflowTest {
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    /**
+     * Run a workflow job using {@link CheckStylePublisher} and check for success.
+     */
+    @Test
+    public void checkstylePublisherWorkflowStep() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "checkstylePublisherWorkflowStep");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("checkstyle-result.xml");
+        report.copyFrom(CheckstyleWorkflowTest.class.getResourceAsStream("/hudson/plugins/checkstyle/parser/checkstyle-result-build1.xml"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'CheckStylePublisher'])\n"
+                        + "}\n", true)
+        );
+        jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        CheckStyleResultAction result = job.getLastBuild().getAction(CheckStyleResultAction.class);
+        assertEquals(1, result.getResult().getAnnotations().size());
+    }
+
+    /**
+     * Run a workflow job using {@link CheckStylePublisher} with a failing threshold of 0, so the given example file
+     * "/hudson/plugins/checkstyle/parser/checkstyle-result-build1.xml" will make the build to fail.
+     */
+    @Test
+    public void checkstylePublisherWorkflowStepSetLimits() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "checkstylePublisherWorkflowStepSetLimits");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("checkstyle-result.xml");
+        report.copyFrom(CheckstyleWorkflowTest.class.getResourceAsStream("/hudson/plugins/checkstyle/parser/checkstyle-result-build1.xml"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'CheckStylePublisher', pattern: '**/checkstyle-result.xml', failedTotalAll: '0', usePreviousBuildAsReference: false])\n"
+                        + "}\n", true)
+        );
+        jenkinsRule.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
+        CheckStyleResultAction result = job.getLastBuild().getAction(CheckStyleResultAction.class);
+        assertEquals(1, result.getResult().getAnnotations().size());
+    }
+
+    /**
+     * Run a workflow job using {@link CheckStylePublisher} with a unstable threshold of 0, so the given example file
+     * "/hudson/plugins/checkstyle/parser/checkstyle-result-build1.xml" will make the build to fail.
+     */
+    @Test
+    public void checkstylePublisherWorkflowStepFailure() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "checkstylePublisherWorkflowStepFailure");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("checkstyle-result.xml");
+        report.copyFrom(CheckstyleWorkflowTest.class.getResourceAsStream("/hudson/plugins/checkstyle/parser/checkstyle-result-build1.xml"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'CheckStylePublisher', pattern: '**/checkstyle-result.xml', unstableTotalAll: '0', usePreviousBuildAsReference: false])\n"
+                        + "}\n")
+        );
+        jenkinsRule.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
+        CheckStyleResultAction result = job.getLastBuild().getAction(CheckStyleResultAction.class);
+        assertEquals(1, result.getResult().getAnnotations().size());
+    }
+}
+


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/analysis-core-plugin/pull/31

Make Checkstyle Plugin compatible with Workflow [JENKINS-29648](https://issues.jenkins-ci.org/browse/JENKINS-29648)

```
node {
  checkout changelog: false, poll: false, scm: [$class: 'SubversionSCM', additionalCredentials: [], excludedCommitMessages: '', excludedRegions: '', excludedRevprop: '', excludedUsers: '', filterChangelog: false, ignoreDirPropChanges: false, includedRegions: '', locations: [[credentialsId: 'efaa090d-5627-4a5c-95df-f570850d89a1', depthOption: 'infinity', ignoreExternalsOption: true, local: '.', remote: 'https://server/svn/repo/trunk']], workspaceUpdater: [$class: 'UpdateUpdater']]
  sh 'mvn clean install -Dmaven.test.skip checkstyle:check'
  step([$class: 'CheckStylePublisher'])
}
```

- [x] Initial source code modifications
- [x] Add an automated test specific for Workflow compatibility