### PR TITLE
Added symbol name for better pipeline integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
       <version>3.2</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>analysis-test</artifactId>
       <version>1.18</version>

--- a/src/main/java/hudson/plugins/checkstyle/CheckStyleDescriptor.java
+++ b/src/main/java/hudson/plugins/checkstyle/CheckStyleDescriptor.java
@@ -2,13 +2,14 @@ package hudson.plugins.checkstyle;
 
 import hudson.Extension;
 import hudson.plugins.analysis.core.PluginDescriptor;
+import org.jenkinsci.Symbol;
 
 /**
  * Descriptor for the class {@link CheckStylePublisher}.
  *
  * @author Ulli Hafner
  */
-@Extension(ordinal = 100) // NOCHECKSTYLE
+@Extension(ordinal = 100) @Symbol("checkstyle") // NOCHECKSTYLE
 public final class CheckStyleDescriptor extends PluginDescriptor {
     /** The ID of this plug-in is used as URL. */
     static final String PLUGIN_ID = "checkstyle";


### PR DESCRIPTION
This will improve the syntax of using Findbugs from Jenkins Pipeline.

Before:
```
step([$class: 'CheckStylePublisher', pattern: 'target/checkstyle-result.xml'])
```
After:
```
checkstyle(pattern: 'target/checkstyle-result.xml')
```
